### PR TITLE
Switch to Allman braces

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -21,7 +21,7 @@ AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
 BinPackArguments: true
 BinPackParameters: true
-BreakBeforeBraces: GNU
+BreakBeforeBraces: Allman
 BreakBeforeTernaryOperators: false
 ColumnLimit: 80
 IndentWidth: 4


### PR DESCRIPTION
GNU is a horrid style and nobody should be subjected to it, but it's also objectively wrong in this case.